### PR TITLE
Fix browser compatibility issue with replace() and replaceAll()

### DIFF
--- a/src/components/Results.js
+++ b/src/components/Results.js
@@ -10,7 +10,7 @@ export default class Results extends React.Component {
     return this.props.results.results.map((result, index) =>
       <tr key={result.term}>
         <td>{index + 1}</td>
-        <td><a href={`https://www.google.com/search?q=${result.term.replaceAll(" ", "+")}`} target="_blank" rel="noopener noreferrer">{result.term}</a></td>
+        <td><a href={`https://www.google.com/search?q=${result.term.replace(/ /g, "+")}`} target="_blank" rel="noopener noreferrer">{result.term}</a></td>
         <td>{result.similarity}</td>
       </tr>
     )


### PR DESCRIPTION
Google Chrome kept crashing because replaceAll() is not supported until Chrome 85 (to be released later in August). For browser compatibility reasons, changed this to replace() which eliminates this problem. 